### PR TITLE
Some fixes

### DIFF
--- a/errors/400.html
+++ b/errors/400.html
@@ -3,7 +3,7 @@
   <title>Bad Request - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/400.html
+++ b/errors/400.html
@@ -3,7 +3,7 @@
   <title>Bad Request - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/401.html
+++ b/errors/401.html
@@ -3,7 +3,7 @@
   <title>Unauthorized - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/401.html
+++ b/errors/401.html
@@ -3,7 +3,7 @@
   <title>Unauthorized - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/402.html
+++ b/errors/402.html
@@ -3,7 +3,7 @@
   <title>Payment Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/402.html
+++ b/errors/402.html
@@ -3,7 +3,7 @@
   <title>Payment Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/403.html
+++ b/errors/403.html
@@ -3,7 +3,7 @@
   <title>Forbidden - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/403.html
+++ b/errors/403.html
@@ -3,7 +3,7 @@
   <title>Forbidden - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/404.html
+++ b/errors/404.html
@@ -3,7 +3,7 @@
   <title>Not Found - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/404.html
+++ b/errors/404.html
@@ -3,7 +3,7 @@
   <title>Not Found - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/405.html
+++ b/errors/405.html
@@ -3,7 +3,7 @@
   <title>Method Not Allowed - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/405.html
+++ b/errors/405.html
@@ -3,7 +3,7 @@
   <title>Method Not Allowed - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/406.html
+++ b/errors/406.html
@@ -3,7 +3,7 @@
   <title>Not Acceptable - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/406.html
+++ b/errors/406.html
@@ -3,7 +3,7 @@
   <title>Not Acceptable - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/407.html
+++ b/errors/407.html
@@ -3,7 +3,7 @@
   <title>Proxy Authentication Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/407.html
+++ b/errors/407.html
@@ -3,7 +3,7 @@
   <title>Proxy Authentication Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/408.html
+++ b/errors/408.html
@@ -3,7 +3,7 @@
   <title>Request Timeout - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/408.html
+++ b/errors/408.html
@@ -3,7 +3,7 @@
   <title>Request Timeout - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/409.html
+++ b/errors/409.html
@@ -3,7 +3,7 @@
   <title>Conflict - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/409.html
+++ b/errors/409.html
@@ -3,7 +3,7 @@
   <title>Conflict - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/410.html
+++ b/errors/410.html
@@ -3,7 +3,7 @@
   <title>Gone - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/410.html
+++ b/errors/410.html
@@ -3,7 +3,7 @@
   <title>Gone - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/411.html
+++ b/errors/411.html
@@ -3,7 +3,7 @@
   <title>Length Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/411.html
+++ b/errors/411.html
@@ -3,7 +3,7 @@
   <title>Length Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/412.html
+++ b/errors/412.html
@@ -3,7 +3,7 @@
   <title>Precondition Failed - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/412.html
+++ b/errors/412.html
@@ -3,7 +3,7 @@
   <title>Precondition Failed - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/413.html
+++ b/errors/413.html
@@ -3,7 +3,7 @@
   <title>Payload Too Large - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/413.html
+++ b/errors/413.html
@@ -3,7 +3,7 @@
   <title>Payload Too Large - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/414.html
+++ b/errors/414.html
@@ -3,7 +3,7 @@
   <title>URI Too Long - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/414.html
+++ b/errors/414.html
@@ -3,7 +3,7 @@
   <title>URI Too Long - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/415.html
+++ b/errors/415.html
@@ -3,7 +3,7 @@
   <title>Unsupported Media Type - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/415.html
+++ b/errors/415.html
@@ -3,7 +3,7 @@
   <title>Unsupported Media Type - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/416.html
+++ b/errors/416.html
@@ -3,7 +3,7 @@
   <title>Range Not Satisfiable - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/416.html
+++ b/errors/416.html
@@ -3,7 +3,7 @@
   <title>Range Not Satisfiable - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/417.html
+++ b/errors/417.html
@@ -3,7 +3,7 @@
   <title>Expectation Failed - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/417.html
+++ b/errors/417.html
@@ -3,7 +3,7 @@
   <title>Expectation Failed - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/418.html
+++ b/errors/418.html
@@ -3,7 +3,7 @@
   <title>I'm a teapot - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/418.html
+++ b/errors/418.html
@@ -3,7 +3,7 @@
   <title>I'm a teapot - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/421.html
+++ b/errors/421.html
@@ -3,7 +3,7 @@
   <title>Misdirected Request - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/421.html
+++ b/errors/421.html
@@ -3,7 +3,7 @@
   <title>Misdirected Request - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/422.html
+++ b/errors/422.html
@@ -3,7 +3,7 @@
   <title>Unprocessable Entity - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/422.html
+++ b/errors/422.html
@@ -3,7 +3,7 @@
   <title>Unprocessable Entity - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/423.html
+++ b/errors/423.html
@@ -3,7 +3,7 @@
   <title>Locked - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/423.html
+++ b/errors/423.html
@@ -3,7 +3,7 @@
   <title>Locked - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/424.html
+++ b/errors/424.html
@@ -3,7 +3,7 @@
   <title>Failed Dependency - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/424.html
+++ b/errors/424.html
@@ -3,7 +3,7 @@
   <title>Failed Dependency - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/425.html
+++ b/errors/425.html
@@ -3,7 +3,7 @@
   <title>Too Early - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/425.html
+++ b/errors/425.html
@@ -3,7 +3,7 @@
   <title>Too Early - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/426.html
+++ b/errors/426.html
@@ -3,7 +3,7 @@
   <title>Upgrade Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/426.html
+++ b/errors/426.html
@@ -3,7 +3,7 @@
   <title>Upgrade Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/428.html
+++ b/errors/428.html
@@ -3,7 +3,7 @@
   <title>Precondition Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/428.html
+++ b/errors/428.html
@@ -3,7 +3,7 @@
   <title>Precondition Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/429.html
+++ b/errors/429.html
@@ -3,7 +3,7 @@
   <title>Too Many Requests - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/429.html
+++ b/errors/429.html
@@ -3,7 +3,7 @@
   <title>Too Many Requests - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/431.html
+++ b/errors/431.html
@@ -3,7 +3,7 @@
   <title>Request Header Fields Too Large - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/431.html
+++ b/errors/431.html
@@ -3,7 +3,7 @@
   <title>Request Header Fields Too Large - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/451.html
+++ b/errors/451.html
@@ -3,7 +3,7 @@
   <title>Unavailable For Legal Reasons - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/451.html
+++ b/errors/451.html
@@ -3,7 +3,7 @@
   <title>Unavailable For Legal Reasons - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/500.html
+++ b/errors/500.html
@@ -3,7 +3,7 @@
   <title>Internal server error - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/500.html
+++ b/errors/500.html
@@ -3,7 +3,7 @@
   <title>Internal server error - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/501.html
+++ b/errors/501.html
@@ -3,7 +3,7 @@
   <title>Not Implemented - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/501.html
+++ b/errors/501.html
@@ -3,7 +3,7 @@
   <title>Not Implemented - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/502.html
+++ b/errors/502.html
@@ -3,7 +3,7 @@
   <title>Bad Gateway - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/502.html
+++ b/errors/502.html
@@ -3,7 +3,7 @@
   <title>Bad Gateway - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/503.html
+++ b/errors/503.html
@@ -3,7 +3,7 @@
   <title>Service Unavailable - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/503.html
+++ b/errors/503.html
@@ -3,7 +3,7 @@
   <title>Service Unavailable - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/504.html
+++ b/errors/504.html
@@ -3,7 +3,7 @@
   <title>Gateway Timeout - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/504.html
+++ b/errors/504.html
@@ -3,7 +3,7 @@
   <title>Gateway Timeout - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/505.html
+++ b/errors/505.html
@@ -3,7 +3,7 @@
   <title>HTTP Version Not Supported - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/505.html
+++ b/errors/505.html
@@ -3,7 +3,7 @@
   <title>HTTP Version Not Supported - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/506.html
+++ b/errors/506.html
@@ -3,7 +3,7 @@
   <title>Variant Also Negotiates - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/506.html
+++ b/errors/506.html
@@ -3,7 +3,7 @@
   <title>Variant Also Negotiates - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/507.html
+++ b/errors/507.html
@@ -3,7 +3,7 @@
   <title>Insufficient Storage - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/507.html
+++ b/errors/507.html
@@ -3,7 +3,7 @@
   <title>Insufficient Storage - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/508.html
+++ b/errors/508.html
@@ -3,7 +3,7 @@
   <title>Error 508 - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/508.html
+++ b/errors/508.html
@@ -3,7 +3,7 @@
   <title>Error 508 - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/510.html
+++ b/errors/510.html
@@ -3,7 +3,7 @@
   <title>Not Extended - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/510.html
+++ b/errors/510.html
@@ -3,7 +3,7 @@
   <title>Not Extended - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/511.html
+++ b/errors/511.html
@@ -3,7 +3,7 @@
   <title>Network Authentication Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/errors/511.html
+++ b/errors/511.html
@@ -3,7 +3,7 @@
   <title>Network Authentication Required - <!--# echo var="host" default=""--></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1, maximum-scale=1"> 
-  <link rel="stylesheet" href="/assets/css/style.css" type="text/css">
+  <link rel="stylesheet" href="/.nginx-errors/assets/css/style.css" type="text/css">
 </head>
 <body>
   <main>

--- a/nginx-errors.conf
+++ b/nginx-errors.conf
@@ -42,6 +42,5 @@ error_page 511 /.nginx-errors/511.html;
 location /.nginx-errors {
   ssi on;
   allow all;
-  internal;
   alias /usr/share/nginx/html/nginx-errors/errors/;
 }

--- a/nginx-errors.conf
+++ b/nginx-errors.conf
@@ -1,57 +1,47 @@
-error_page 400 /nginx-errors/errors/400.html;
-error_page 401 /nginx-errors/errors/401.html;
-error_page 402 /nginx-errors/errors/402.html;
-error_page 403 /nginx-errors/errors/403.html;
-error_page 404 /nginx-errors/errors/404.html;
-error_page 405 /nginx-errors/errors/405.html;
-error_page 406 /nginx-errors/errors/406.html;
-error_page 407 /nginx-errors/errors/407.html;
-error_page 408 /nginx-errors/errors/408.html;
-error_page 409 /nginx-errors/errors/409.html;
-error_page 410 /nginx-errors/errors/410.html;
-error_page 411 /nginx-errors/errors/411.html;
-error_page 412 /nginx-errors/errors/412.html;
-error_page 413 /nginx-errors/errors/413.html;
-error_page 414 /nginx-errors/errors/414.html;
-error_page 415 /nginx-errors/errors/415.html;
-error_page 416 /nginx-errors/errors/416.html;
-error_page 417 /nginx-errors/errors/417.html;
-error_page 418 /nginx-errors/errors/418.html;
-error_page 421 /nginx-errors/errors/421.html;
-error_page 422 /nginx-errors/errors/422.html;
-error_page 423 /nginx-errors/errors/423.html;
-error_page 424 /nginx-errors/errors/424.html;
-error_page 425 /nginx-errors/errors/425.html;
-error_page 426 /nginx-errors/errors/426.html;
-error_page 428 /nginx-errors/errors/428.html;
-error_page 429 /nginx-errors/errors/429.html;
-error_page 431 /nginx-errors/errors/431.html;
-error_page 451 /nginx-errors/errors/451.html;
-error_page 500 /nginx-errors/errors/500.html;
-error_page 501 /nginx-errors/errors/501.html;
-error_page 502 /nginx-errors/errors/502.html;
-error_page 503 /nginx-errors/errors/503.html;
-error_page 504 /nginx-errors/errors/504.html;
-error_page 505 /nginx-errors/errors/505.html;
-error_page 506 /nginx-errors/errors/506.html;
-error_page 507 /nginx-errors/errors/507.html;
-error_page 508 /nginx-errors/errors/508.html;
-error_page 510 /nginx-errors/errors/510.html;
-error_page 511 /nginx-errors/errors/511.html;
+error_page 400 /.nginx-errors/400.html;
+error_page 401 /.nginx-errors/401.html;
+error_page 402 /.nginx-errors/402.html;
+error_page 403 /.nginx-errors/403.html;
+error_page 404 /.nginx-errors/404.html;
+error_page 405 /.nginx-errors/405.html;
+error_page 406 /.nginx-errors/406.html;
+error_page 407 /.nginx-errors/407.html;
+error_page 408 /.nginx-errors/408.html;
+error_page 409 /.nginx-errors/409.html;
+error_page 410 /.nginx-errors/410.html;
+error_page 411 /.nginx-errors/411.html;
+error_page 412 /.nginx-errors/412.html;
+error_page 413 /.nginx-errors/413.html;
+error_page 414 /.nginx-errors/414.html;
+error_page 415 /.nginx-errors/415.html;
+error_page 416 /.nginx-errors/416.html;
+error_page 417 /.nginx-errors/417.html;
+error_page 418 /.nginx-errors/418.html;
+error_page 421 /.nginx-errors/421.html;
+error_page 422 /.nginx-errors/422.html;
+error_page 423 /.nginx-errors/423.html;
+error_page 424 /.nginx-errors/424.html;
+error_page 425 /.nginx-errors/425.html;
+error_page 426 /.nginx-errors/426.html;
+error_page 428 /.nginx-errors/428.html;
+error_page 429 /.nginx-errors/429.html;
+error_page 431 /.nginx-errors/431.html;
+error_page 451 /.nginx-errors/451.html;
+error_page 500 /.nginx-errors/500.html;
+error_page 501 /.nginx-errors/501.html;
+error_page 502 /.nginx-errors/502.html;
+error_page 503 /.nginx-errors/503.html;
+error_page 504 /.nginx-errors/504.html;
+error_page 505 /.nginx-errors/505.html;
+error_page 506 /.nginx-errors/506.html;
+error_page 507 /.nginx-errors/507.html;
+error_page 508 /.nginx-errors/508.html;
+error_page 510 /.nginx-errors/510.html;
+error_page 511 /.nginx-errors/511.html;
 
-location ^~ /nginx-errors/errors/ {
-    ssi on;
-    internal;
-    allow all;
-    root /usr/share/nginx/html;
-}
-
-location ^~ /assets/css/style.css {
-    allow all;
-    root /usr/share/nginx/html/nginx-errors/errors;
-}
-
-location ~* montserrat-(400|700).(eot|woff2|woff|ttf|svg) {
-    allow all;
-    root /usr/share/nginx/html/nginx-errors/errors;
+location /.nginx-errors {
+  ssi on;
+  allow all;
+  internal;
+  alias /usr/share/nginx/html/nginx-errors/errors/;
 }

--- a/nginx-errors.conf
+++ b/nginx-errors.conf
@@ -42,13 +42,16 @@ error_page 511 /nginx-errors/errors/511.html;
 location ^~ /nginx-errors/errors/ {
     ssi on;
     internal;
+    allow all;
     root /usr/share/nginx/html;
 }
 
 location ^~ /assets/css/style.css {
+    allow all;
     root /usr/share/nginx/html/nginx-errors/errors;
 }
 
 location ~* montserrat-(400|700).(eot|woff2|woff|ttf|svg) {
+    allow all;
     root /usr/share/nginx/html/nginx-errors/errors;
 }


### PR DESCRIPTION
- Load assets from /assets to display error pages correctly when loading from subfolders
- Always permit assets, which will make it working e.g. with allow/deny ip addresses
- Move error pages to /.nginx-errors to avoid collisions with the asset folder of some web apps 